### PR TITLE
Making kms_key_arn a module parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ module "rds-snapshot-cleaner" {
 | cloudwatch\_logs\_retention\_days | Number of days to keep logs in AWS CloudWatch. | string | `"90"` | no |
 | environment | Environment tag, e.g prod. | string | n/a | yes |
 | interval\_minutes | How often to run the Lambda function in minutes. | string | `"5"` | no |
+| kms\_key\_arn | ARN of the KMS key used for encrypting environment variables. | string | `""` | no |
 | s3\_bucket | The name of the S3 bucket used to store the Lambda builds. | string | n/a | yes |
 | version\_to\_deploy | The version the Lambda function to deploy. | string | n/a | yes |
 

--- a/main.tf
+++ b/main.tf
@@ -176,7 +176,7 @@ resource "aws_lambda_function" "main" {
   timeout       = "60"
 
   # Default AWS managed key for lambda functions
-  kms_key_arn = "arn:aws:kms:us-west-2:923914045601:key/1408a5f1-c280-4e54-9276-f68169fbf165"
+  kms_key_arn = var.kms_key_arn
 
   environment {
     variables = {

--- a/variables.tf
+++ b/variables.tf
@@ -34,6 +34,12 @@ variable "interval_minutes" {
   type        = string
 }
 
+variable "kms_key_arn" {
+  description = "ARN of the KMS key used for encrypting environment variables."
+  type        = string
+  default     = ""
+}
+
 variable "s3_bucket" {
   description = "The name of the S3 bucket used to store the Lambda builds."
   type        = string


### PR DESCRIPTION
This fixes an issue due to a hardcoded KMS key in the previous version; it makes it an optional variable that can be provided when called. According to the [aws_lambda_function docs](https://www.terraform.io/docs/providers/aws/r/lambda_function.html), this should use the CMK if there's no key specified -- this is the pattern used in the slack notification module, for instance.