### PR TITLE
Replace circleci docker primary

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,12 @@
 version: 2.1
 
 references:
-  circleci_docker_primary: &circleci_docker_primary trussworks/circleci-docker-primary:822fac1c30f3bb7d5d595bed5d2dc86265c4f2f0
+  circleci: &circleci trussworks/circleci:29ab89fdada1f85c5d8fb685a2c71660f0c5f60c
 
 jobs:
   validate:
     docker:
-      - image: *circleci_docker_primary
+      - image: *circleci
     steps:
       - checkout
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,12 @@
 version: 2.1
 
 references:
-  circleci: &circleci trussworks/circleci:29ab89fdada1f85c5d8fb685a2c71660f0c5f60c
+  circleci_beep: &circleci_beep trussworks/circleci:29ab89fdada1f85c5d8fb685a2c71660f0c5f60c
 
 jobs:
   validate:
     docker:
-      - image: *circleci
+      - image: *circleci_beep
     steps:
       - checkout
       - restore_cache:

--- a/README.md
+++ b/README.md
@@ -37,14 +37,14 @@ module "rds-snapshot-cleaner" {
 
 | Name | Version |
 |------|---------|
-| terraform | ~> 0.12.0 |
-| aws | ~> 2.70 |
+| terraform | ~> 0.13.0 |
+| aws | ~> 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.70 |
+| aws | ~> 3.0 |
 
 ## Inputs
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,11 @@ Creates the following resources:
 
 ## Terraform Versions
 
-Terraform 0.12: Pin module version to ~> 2.0.0. Submit pull requests to master branch.
-Terraform 0.11: Pin module version to ~> 1.0.0. Submit pull requests to terraform011 branch.
+Terraform 0.13: Pin module version to ~> 3.X. Submit pull requests to master branch.
+
+Terraform 0.12: Pin module version to ~> 2.X. Submit pull requests to terraform012 branch.
+
+Terraform 0.11: Pin module version to ~> 1.X. Submit pull requests to terraform011 branch.
 
 ## Usage
 

--- a/versions.tf
+++ b/versions.tf
@@ -1,7 +1,7 @@
 terraform {
-  required_version = "~> 0.12.0"
+  required_version = "~> 0.13.0"
 
   required_providers {
-    aws = "~> 2.70"
+    aws = "~> 3.0"
   }
 }


### PR DESCRIPTION
# [Tracker story](https://www.pivotaltracker.com/story/show/174581758)

<!--
    Insert the tracker story URL in the markdown link above
    e.g., Fixes [#1324235](http://path/to/storyid/1324235)
--->

Changes proposed in this pull request:

- Replace `circleci-docker-primary` with `circleci` docker images
- Upgrade to terraform 13 since `circleci` is built with that version of TF
- Upgrade AWS provider to 3.0

## Checklist for Terraform changes

<!--
    - [x] a checked item
    - [ ] an unchecked item
-->

- [ ] Type `atlantis plan` as a Github comment to share your Terraform plan
- [ ] Get PR approval
- [ ] Type `atlantis apply`as a Github comment to apply and merge the plan

If the apply is successful, Atlantis will delete the branch and plan file.

---
<details><summary>Terraform plan</summary>

```terraform
Add Terraform plan here
```

</details>
