### PR TITLE
NT: ability to encrypt cloudwatch log group

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     - auth:
         password: $DOCKER_PASSWORD
         username: $DOCKER_USERNAME
-      image: trussworks/circleci:efb1042e31538677779971798e0912390f699e72
+      image: trussworks/circleci:29ab89fdada1f85c5d8fb685a2c71660f0c5f60c
     steps:
     - checkout
     - restore_cache:

--- a/.markdownlintrc
+++ b/.markdownlintrc
@@ -4,5 +4,5 @@
   "first-line-h1": false,
   "line_length": false,
   "no-multiple-blanks": false,
-  no-inline-html": false
+  "no-inline-html": false
 }

--- a/.markdownlintrc
+++ b/.markdownlintrc
@@ -3,5 +3,6 @@
   "first-header-h1": false,
   "first-line-h1": false,
   "line_length": false,
-  "no-multiple-blanks": false
+  "no-multiple-blanks": false,
+  no-inline-html": false
 }

--- a/README.md
+++ b/README.md
@@ -45,46 +45,26 @@ module "rds-snapshot-cleaner" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.0 |
-
-## Modules
-
-No modules.
-
-## Resources
-
-| Name | Type |
-|------|------|
-| [aws_cloudwatch_event_rule.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
-| [aws_cloudwatch_event_target.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
-| [aws_cloudwatch_log_group.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
-| [aws_iam_role.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
-| [aws_iam_role_policy.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
-| [aws_lambda_function.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
-| [aws_lambda_permission.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
-| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
-| [aws_iam_policy_document.assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
-| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
+| aws | >= 3.0 |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_cleaner_db_instance_identifier"></a> [cleaner\_db\_instance\_identifier](#input\_cleaner\_db\_instance\_identifier) | The RDS database instance identifier. | `string` | n/a | yes |
-| <a name="input_cleaner_dry_run"></a> [cleaner\_dry\_run](#input\_cleaner\_dry\_run) | Don't make any changes and log what would have happened. | `string` | n/a | yes |
-| <a name="input_cleaner_max_db_snapshot_count"></a> [cleaner\_max\_db\_snapshot\_count](#input\_cleaner\_max\_db\_snapshot\_count) | The maximum number of manual snapshots allowed. This takes precedence over -retention-days. | `string` | `""` | no |
-| <a name="input_cleaner_retention_days"></a> [cleaner\_retention\_days](#input\_cleaner\_retention\_days) | The maximum retention age in days. | `string` | n/a | yes |
-| <a name="input_cloudwatch_kms_key_arn"></a> [cloudwatch\_kms\_key\_arn](#input\_cloudwatch\_kms\_key\_arn) | ARN of the Cloudwatch KMS key used for encrypting Cloudwatch log groups. | `string` | `""` | no |
-| <a name="input_cloudwatch_logs_retention_days"></a> [cloudwatch\_logs\_retention\_days](#input\_cloudwatch\_logs\_retention\_days) | Number of days to keep logs in AWS CloudWatch. | `string` | `90` | no |
-| <a name="input_environment"></a> [environment](#input\_environment) | Environment tag, e.g prod. | `any` | n/a | yes |
-| <a name="input_interval_minutes"></a> [interval\_minutes](#input\_interval\_minutes) | How often to run the Lambda function in minutes. | `string` | `5` | no |
-| <a name="input_kms_key_arn"></a> [kms\_key\_arn](#input\_kms\_key\_arn) | ARN of the KMS key used for encrypting environment variables. | `string` | `""` | no |
-| <a name="input_s3_bucket"></a> [s3\_bucket](#input\_s3\_bucket) | The name of the S3 bucket used to store the Lambda builds. | `string` | n/a | yes |
-| <a name="input_version_to_deploy"></a> [version\_to\_deploy](#input\_version\_to\_deploy) | The version the Lambda function to deploy. | `string` | n/a | yes |
+| cleaner\_db\_instance\_identifier | The RDS database instance identifier. | `string` | n/a | yes |
+| cleaner\_dry\_run | Don't make any changes and log what would have happened. | `string` | n/a | yes |
+| cleaner\_max\_db\_snapshot\_count | The maximum number of manual snapshots allowed. This takes precedence over -retention-days. | `string` | `""` | no |
+| cleaner\_retention\_days | The maximum retention age in days. | `string` | n/a | yes |
+| cloudwatch\_kms\_key\_arn | ARN of the Cloudwatch KMS key used for encrypting Cloudwatch log groups. | `string` | `""` | no |
+| cloudwatch\_logs\_retention\_days | Number of days to keep logs in AWS CloudWatch. | `string` | `90` | no |
+| environment | Environment tag, e.g prod. | `any` | n/a | yes |
+| interval\_minutes | How often to run the Lambda function in minutes. | `string` | `5` | no |
+| kms\_key\_arn | ARN of the KMS key used for encrypting environment variables. | `string` | `""` | no |
+| s3\_bucket | The name of the S3 bucket used to store the Lambda builds. | `string` | n/a | yes |
+| version\_to\_deploy | The version the Lambda function to deploy. | `string` | n/a | yes |
 
 ## Outputs
 
-No outputs.
+No output.
+
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/README.md
+++ b/README.md
@@ -38,32 +38,53 @@ module "rds-snapshot-cleaner" {
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.13.0 |
-| aws | >= 3.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_cloudwatch_event_rule.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
+| [aws_cloudwatch_event_target.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
+| [aws_cloudwatch_log_group.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
+| [aws_iam_role.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_lambda_function.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
+| [aws_lambda_permission.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_policy_document.assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| cleaner\_db\_instance\_identifier | The RDS database instance identifier. | `string` | n/a | yes |
-| cleaner\_dry\_run | Don't make any changes and log what would have happened. | `string` | n/a | yes |
-| cleaner\_max\_db\_snapshot\_count | The maximum number of manual snapshots allowed. This takes precedence over -retention-days. | `string` | `""` | no |
-| cleaner\_retention\_days | The maximum retention age in days. | `string` | n/a | yes |
-| cloudwatch\_logs\_retention\_days | Number of days to keep logs in AWS CloudWatch. | `string` | `90` | no |
-| environment | Environment tag, e.g prod. | `any` | n/a | yes |
-| interval\_minutes | How often to run the Lambda function in minutes. | `string` | `5` | no |
-| kms\_key\_arn | ARN of the KMS key used for encrypting environment variables. | `string` | `""` | no |
-| s3\_bucket | The name of the S3 bucket used to store the Lambda builds. | `string` | n/a | yes |
-| version\_to\_deploy | The version the Lambda function to deploy. | `string` | n/a | yes |
+| <a name="input_cleaner_db_instance_identifier"></a> [cleaner\_db\_instance\_identifier](#input\_cleaner\_db\_instance\_identifier) | The RDS database instance identifier. | `string` | n/a | yes |
+| <a name="input_cleaner_dry_run"></a> [cleaner\_dry\_run](#input\_cleaner\_dry\_run) | Don't make any changes and log what would have happened. | `string` | n/a | yes |
+| <a name="input_cleaner_max_db_snapshot_count"></a> [cleaner\_max\_db\_snapshot\_count](#input\_cleaner\_max\_db\_snapshot\_count) | The maximum number of manual snapshots allowed. This takes precedence over -retention-days. | `string` | `""` | no |
+| <a name="input_cleaner_retention_days"></a> [cleaner\_retention\_days](#input\_cleaner\_retention\_days) | The maximum retention age in days. | `string` | n/a | yes |
+| <a name="input_cloudwatch_kms_key_arn"></a> [cloudwatch\_kms\_key\_arn](#input\_cloudwatch\_kms\_key\_arn) | ARN of the Cloudwatch KMS key used for encrypting Cloudwatch log groups. | `string` | `""` | no |
+| <a name="input_cloudwatch_logs_retention_days"></a> [cloudwatch\_logs\_retention\_days](#input\_cloudwatch\_logs\_retention\_days) | Number of days to keep logs in AWS CloudWatch. | `string` | `90` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment tag, e.g prod. | `any` | n/a | yes |
+| <a name="input_interval_minutes"></a> [interval\_minutes](#input\_interval\_minutes) | How often to run the Lambda function in minutes. | `string` | `5` | no |
+| <a name="input_kms_key_arn"></a> [kms\_key\_arn](#input\_kms\_key\_arn) | ARN of the KMS key used for encrypting environment variables. | `string` | `""` | no |
+| <a name="input_s3_bucket"></a> [s3\_bucket](#input\_s3\_bucket) | The name of the S3 bucket used to store the Lambda builds. | `string` | n/a | yes |
+| <a name="input_version_to_deploy"></a> [version\_to\_deploy](#input\_version\_to\_deploy) | The version the Lambda function to deploy. | `string` | n/a | yes |
 
 ## Outputs
 
-No output.
-
+No outputs.
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ module "rds-snapshot-cleaner" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
+| terraform | >= 0.13.0 |
+| aws | >= 3.0 |
 
 ## Providers
 

--- a/main.tf
+++ b/main.tf
@@ -107,6 +107,7 @@ resource "aws_cloudwatch_log_group" "main" {
   # This name must match the lambda function name and should not be changed
   name              = "/aws/lambda/${local.name}-${var.cleaner_db_instance_identifier}"
   retention_in_days = var.cloudwatch_logs_retention_days
+  kms_key_id        = var.cloudwatch_kms_key_arn
 
   tags = {
     Name        = "${local.name}-${var.cleaner_db_instance_identifier}"

--- a/variables.tf
+++ b/variables.tf
@@ -41,6 +41,12 @@ variable "kms_key_arn" {
   default     = ""
 }
 
+variable "cloudwatch_kms_key_arn" {
+  description = "ARN of the Cloudwatch KMS key used for encrypting Cloudwatch log groups."
+  type        = string
+  default     = ""
+}
+
 variable "s3_bucket" {
   description = "The name of the S3 bucket used to store the Lambda builds."
   type        = string


### PR DESCRIPTION
Adds the ability to optionally add encryption to cloudwatch log groups created by the rds snapshot cleaner