### PR TITLE
B-19459-IAC-UPDATE

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -52,7 +52,7 @@ data "aws_iam_policy_document" "main" {
     ]
 
     resources = [
-      "arn:${data.aws_partition.current.partition}:rds:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:db:${var.cleaner_db_instance_identifier}",
+      # "arn:${data.aws_partition.current.partition}:rds:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:db:${var.cleaner_db_instance_identifier}",
       "arn:${data.aws_partition.current.partition}:rds:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:snapshot:${var.cleaner_db_instance_identifier}-*",
     ]
   }


### PR DESCRIPTION
Update so the cleaner can't read snapshots that don't start with the correct prefix and attempt to delete them, which causes an unauthorized api call exception.